### PR TITLE
change template data to be workflow prompts rather than descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/sensedoing-task-template.md
+++ b/.github/ISSUE_TEMPLATE/sensedoing-task-template.md
@@ -1,7 +1,7 @@
 ---
-name: SenseDoing Task template
-about: Easily start a SenseDoing task
-title: ''
+name: Create a SenseDoing task
+about: Click the green "Get Started" button to create a new SenseDoing task
+title: '(put a title for your task here)'
 labels: SenseDoing
 assignees: ''
 


### PR DESCRIPTION
The intent of this PR is to improve the UX of creating a new SenseDoing issue, by changing the titles to be messages that tell the user (who may not be a GitHub expert) what they should do.

To compare with the current workflow, try creating a new issue and imagine swapping in the new metadata in this PR.